### PR TITLE
Update sharp.c

### DIFF
--- a/sharp.c
+++ b/sharp.c
@@ -396,7 +396,7 @@ err:
     return 0;
 }
 
-static int sharp_remove(struct spi_device *spi)
+static void sharp_remove(struct spi_device *spi)
 {
         if (info) {
                 unregister_framebuffer(info);
@@ -405,9 +405,8 @@ static int sharp_remove(struct spi_device *spi)
         }
 	kthread_stop(thread1);
 	kthread_stop(fpsThread);
-    kthread_stop(vcomToggleThread);
+    	kthread_stop(vcomToggleThread);
 	printk(KERN_CRIT "out of screen module");
-	return 0;
 }
 
 static struct spi_driver sharp_driver = {


### PR DESCRIPTION
Change return value of methode from 'int' to 'void' and removed therefor the statement "return 0" in line 410 so the error "Sharp-Memory-LCD-Kernel-Driver/sharp.c:415:23:error: initialization of 'void () (struct spi device * from incompatible pointer type 'int () (struct spi_device *) ' [-Werror-incompatible-pointer-types]" is solved